### PR TITLE
fix: Implementa sticky footer para corrigir espaço em branco

### DIFF
--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -7,7 +7,7 @@
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/custom.css') }}">
 </head>
-<body>
+<body class="d-flex flex-column min-vh-100">
 
     <header class="main-header p-3 mb-3 border-bottom">
         <div class="container">
@@ -108,7 +108,7 @@
         </div>
     </header>
     
-    <main class="container">
+    <main class="container flex-grow-1">
         {% block content %}
         {% endblock %}
     </main>


### PR DESCRIPTION
Aplica classes de utilitário Flexbox do Bootstrap 5 ao template `base.html` para garantir que o rodapé permaneça na parte inferior da página, mesmo em páginas com pouco conteúdo.

- Adiciona `d-flex flex-column min-vh-100` à tag `<body>`.
- Adiciona `flex-grow-1` à tag `<main>` para que ela ocupe o espaço disponível.